### PR TITLE
Makefile: fix cannot find libucode and libubox when running ucode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 
 HOST_BUILD_DEPENDS:=ucode/host libubox/host
 PKG_BUILD_DEPENDS:=bpf-headers ufp/host
+UCODE:=LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):$(STAGING_DIR_HOSTPKG)/lib/:$(STAGING_DIR_HOST)/lib/ $(STAGING_DIR_HOSTPKG)/bin/ucode
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
@@ -39,7 +40,7 @@ endef
 define Package/ufp/install
 	$(INSTALL_DIR) $(1)/usr/lib/ucode $(1)/usr/share/ufp
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/ucode/uht.so $(1)/usr/lib/ucode/
-	ucode ./scripts/convert-devices.uc $(1)/usr/share/ufp/devices.bin ./data/*.json
+	$(UCODE) ./scripts/convert-devices.uc $(1)/usr/share/ufp/devices.bin ./data/*.json
 	$(CP) ./files/* $(1)/
 endef
 


### PR DESCRIPTION
Env: [wlan-ap](https://github.com/Telecominfraproject/wlan-ap/tree/next) 

When install ufp package, host execute `ucode`:
```
ucode ./scripts/convert-devices.uc $(1)/usr/share/ufp/devices.bin ./data/*.json
```

however, it through several errors:
1) Can't find libucode 

```
ucode ./scripts/convert-devices.uc /opt/tip-wlan-ap/openwrt/build_dir/target-mips_24kc_musl/ufp-1/.pkgdir/ufp/usr/share/ufp/devices.bin ./data/*.json
ucode: error while loading shared libraries: libucode.so.20220812: cannot open shared object file: No such file or directory
```
libucode is installed in `staging_dir/hostpkg/lib` or `$(STAGING_DIR_HOSTPKG)/lib`

2) Can't find libubox if not provide path for code
```
Runtime error: Unable to dlopen file '/opt/tip-wlan-ap/openwrt/staging_dir/hostpkg/lib/ucode/uht.so': libubox.so: cannot open shared object file: No such file or directory
In ./scripts/convert-devices.uc, line 4, byte 23:

 `let uht = require("uht");`
  Near here -------------^
```

libubox host is installed in `staging_dir/host/lib/` or `$(STAGING_DIR_HOST)/lib/`